### PR TITLE
fix could not install colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "gulp incremental build on each process.",
   "main": "index.js",
   "dependencies": {
+    "colors": "^1.1.2",
     "glob": "^7.0.5",
     "lodash.defaults": "^4.0.1",
     "through2": "^2.0.1"
   },
   "devDependencies": {
-    "colors": "^1.1.2",
     "gulp-util": "^3.0.7",
     "mocha": "^2.5.3",
     "vinyl": "^1.1.1"


### PR DESCRIPTION
```
Error: Cannot find module 'colors/safe'
    at Function.Module._resolveFilename (module.js:485:15)
    at Function.Module._load (module.js:437:25)
    at Module.require (module.js:513:17)
    at require (internal/module.js:11:18)
    at Object.<anonymous> (path/node_modules/gulp-pcache/index.js:6:14)
    at Module._compile (module.js:569:30)
    at Object.Module._extensions..js (module.js:580:10)
    at Module.load (module.js:503:32)
    at tryModuleLoad (module.js:466:12)
    at Function.Module._load (module.js:458:3)
```